### PR TITLE
Update modifier.escape.php

### DIFF
--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -250,6 +250,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
             }
             return $return;
         default:
+            trigger_error("escape: unsupported type: $esc_type - returning unmodified string", E_USER_NOTICE);
             return $string;
     }
 }


### PR DESCRIPTION
some sort of token warning if perhaps an incorrect modifier was used (E.g.|escape:quotes vs |escape:quote).